### PR TITLE
Fixed bug where purchased upgrades were immediately re-purchasable

### DIFF
--- a/game/src/main/java/WizardQuest/GameUserInterface.java
+++ b/game/src/main/java/WizardQuest/GameUserInterface.java
@@ -955,6 +955,7 @@ EncounterInterface currentEncounter = gameManager.pickEncounter();
 
             try {
                 gameManager.purchaseUpgrade(bought);
+                ownedUpgrades[bought.ordinal()] = true;
                 telemetryListener.onBuyUpgrade(
                         new BuyUpgradeEvent(
                                 settings.getUserID(), gameManager.getSessionID(), timeManager.getCurrentTime(),


### PR DESCRIPTION
Single line addition on line 958 of GameUserInterface, marking an upgrade as purchased